### PR TITLE
tennicam_client_logger and tennicam_client_replay added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 ################
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(ament_cmake_python REQUIRED)
@@ -89,6 +90,8 @@ install_scripts(
   ${CMAKE_CURRENT_LIST_DIR}/bin/tennicam_client_print.py
   ${CMAKE_CURRENT_LIST_DIR}/bin/tennicam_client_display.py
   ${CMAKE_CURRENT_LIST_DIR}/bin/tennicam_client_transform_update.py
+  ${CMAKE_CURRENT_LIST_DIR}/bin/tennicam_client_logger.py
+  ${CMAKE_CURRENT_LIST_DIR}/bin/tennicam_client_replay.py
   DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/
   )
 
@@ -107,6 +110,7 @@ endif()
 install(DIRECTORY
   "${TENNICAM_CLIENT_CONFIG_DIR}" DESTINATION opt/mpi-is/)
 
+
 ###################
 # Python wrappers #
 ###################
@@ -117,7 +121,7 @@ target_link_libraries(${PROJECT_NAME}_py PRIVATE ${PYTHON_LIBRARIES})
 target_link_libraries(${PROJECT_NAME}_py PRIVATE ${PROJECT_NAME})
 set_target_properties(${PROJECT_NAME}_py
   PROPERTIES PREFIX "" SUFFIX "${PYTHON_MODULE_EXTENSION}"
-  OUTPUT_NAME ${PROJECT_NAME})
+  OUTPUT_NAME ${PROJECT_NAME}_wrp)
 target_include_directories(
   ${PROJECT_NAME}_py
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -125,6 +129,13 @@ target_include_directories(
   PUBLIC ${PYTHON_INCLUDE_DIRS})
 _ament_cmake_python_get_python_install_dir()
 install(TARGETS ${PROJECT_NAME}_py DESTINATION ${PYTHON_INSTALL_DIR})
+
+
+######################
+# Python Native code #
+######################
+
+ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR python/${PROJECT_NAME})
 
 
 ######################

--- a/bin/tennicam_client_display.py
+++ b/bin/tennicam_client_display.py
@@ -8,14 +8,10 @@ Required for this executable:
 - in second terminal :'pam_mujoco tennicam_client_display'
 """
 
-import sys
-import time
-import logging
 import o80
 import signal_handler
 import tennicam_client
 import pam_mujoco
-from lightargs import BrightArgs, Positive, FileExists
 
 
 # required for this executable:

--- a/bin/tennicam_client_logger.py
+++ b/bin/tennicam_client_logger.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
 
-import pathlib
-import signal_handler
-import tennicam_client
-from lightargs import BrightArgs
-
 """
 Dump the output of tennicam_client into a file,
 with format for each line:
@@ -16,6 +11,13 @@ with:
 - velocity: 3d tuple
 """
 
+
+import pathlib
+import signal_handler
+import tennicam_client
+from lightargs import BrightArgs
+
+
 TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
 TENNICAM_CLIENT_DEFAULT_FOLDER = pathlib.Path("/tmp")
 
@@ -26,7 +28,7 @@ def _unique_path(
     """
     returns the path to a file /directory/tennicam_{x} that does not exists yet
     """
-    
+
     counter = 0
     while True:
         counter += 1
@@ -41,7 +43,7 @@ def _run(segment_id: str, filepath: pathlib.Path):
     ball observations and dumping a corresponding 
     string in filepath.
     """
-    
+
     frontend = tennicam_client.FrontEnd(segment_id)
     iteration = frontend.latest().get_iteration()
 
@@ -65,7 +67,7 @@ def _configure() -> BrightArgs:
     """
     Configuration dialog
     """
-    
+
     global TENNICAM_CLIENT_DEFAULT_SEGMENT_ID
     global TENNICAM_CLIENT_DEFAULT_FOLDER
     config = BrightArgs("tennicam logger")

--- a/bin/tennicam_client_logger.py
+++ b/bin/tennicam_client_logger.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import pathlib
+import signal_handler
+import tennicam_client
+from lightargs import BrightArgs
+
+"""
+Dump the output of tennicam_client into a file,
+with format for each line:
+ repr([ball_id,time_stamp,position,velocity])
+with:
+- ball_id : int
+- time_stamp: int (nanoseconds)
+- position: 3d tuple
+- velocity: 3d tuple
+"""
+
+TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
+TENNICAM_CLIENT_DEFAULT_FOLDER = pathlib.Path("/tmp")
+
+
+def _unique_path(
+    directory: pathlib.Path, name_pattern="tennicam_{:03d}"
+) -> pathlib.Path:
+    """
+    returns the path to a file /directory/tennicam_{x} that does not exists yet
+    """
+    
+    counter = 0
+    while True:
+        counter += 1
+        path = directory / name_pattern.format(counter)
+        if not path.exists():
+            return path
+
+
+def _run(segment_id: str, filepath: pathlib.Path):
+    """
+    Creates an o80 frontend and uses it to get all
+    ball observations and dumping a corresponding 
+    string in filepath.
+    """
+    
+    frontend = tennicam_client.FrontEnd(segment_id)
+    iteration = frontend.latest().get_iteration()
+
+    getters = ("get_ball_id", "get_time_stamp", "get_position", "get_velocity")
+
+    with filepath.open(mode="w") as f:
+        try:
+            while not signal_handler.has_received_sigint():
+                iteration += 1
+                obs = frontend.read(iteration)
+                values = tuple((getattr(obs, getter)() for getter in getters))
+                f.write(repr(values))
+                f.write("\n")
+        except (KeyboardInterrupt, SystemExit):
+            pass
+        except Exception as e:
+            print("Error:", e)
+
+
+def _configure() -> BrightArgs:
+    """
+    Configuration dialog
+    """
+    
+    global TENNICAM_CLIENT_DEFAULT_SEGMENT_ID
+    global TENNICAM_CLIENT_DEFAULT_FOLDER
+    config = BrightArgs("tennicam logger")
+    config.add_option(
+        "segment_id",
+        TENNICAM_CLIENT_DEFAULT_SEGMENT_ID,
+        "segment_id of the o80 backend",
+        str,
+    )
+    config.add_option(
+        "filepath",
+        str(_unique_path(TENNICAM_CLIENT_DEFAULT_FOLDER)),
+        "absolute path of the log file",
+        str,
+    )
+    change_all = False
+    config.dialog(change_all)
+    print()
+    return config
+
+
+if __name__ == "__main__":
+    config = _configure()
+    segment_id = config.segment_id
+    filepath = pathlib.Path(config.filepath)
+    _run(segment_id, filepath)

--- a/bin/tennicam_client_print.py
+++ b/bin/tennicam_client_print.py
@@ -7,13 +7,8 @@ Required for this executable:
 - in another terminal: 'tennicam_client'
 """
 
-import sys
-import time
-import logging
-import o80
 import signal_handler
 import tennicam_client
-from lightargs import BrightArgs, Positive, FileExists
 
 TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
 

--- a/bin/tennicam_client_replay.py
+++ b/bin/tennicam_client_replay.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+"""
+Display in a mujoco simulated environment the ball
+as logged in a tennicam_{x} file, i.e. a file
+generated via tennicam_client_logger
+Required for this executable:
+- first in another terminal :'pam_mujoco tennicam_client_replay'
+"""
+
+import pathlib
+import o80
+import signal_handler
+import tennicam_client
+import pam_mujoco
+from lightargs import BrightArgs, FileExists
+
+TENNICAM_CLIENT_DEFAULT_FOLDER = pathlib.Path("/tmp")
+TENNICAM_CLIENT_MUJOCO_ID = "tennicam_client_replay"
+
+
+def _get_default_file(
+    directory: pathlib.Path, file_prefix="tennicam_*"
+) -> pathlib.Path:
+    """
+    Returns one of the file "/tmp/tennicam_*"
+    Return empty string if no such file.
+    """
+
+    for filename in directory.glob(file_prefix):
+        if filename.is_file():
+            return directory / filename
+
+    return ""
+
+
+def _configure() -> BrightArgs:
+    """
+    Configuration dialog
+    """
+
+    global TENNICAM_CLIENT_DEFAULT_FOLDER
+    config = BrightArgs("tennicam replay")
+    config.add_option(
+        "filepath",
+        str(_get_default_file(TENNICAM_CLIENT_DEFAULT_FOLDER)),
+        "absolute path of the log file to replay",
+        str,
+        [FileExists],
+    )
+    change_all = False
+    config.dialog(change_all)
+    print()
+    return config
+
+
+def _get_handle() -> pam_mujoco.MujocoHandle:
+    """
+    Configures mujoco to have a controllable ball
+    and returns the handle 
+    """
+
+    global TENNICAM_CLIENT_MUJOCO_ID
+    ball = pam_mujoco.MujocoItem(
+        "ball", control=pam_mujoco.MujocoItem.CONSTANT_CONTROL, color=(1, 0, 0, 1)
+    )
+    graphics = True
+    accelerated_time = False
+    handle = pam_mujoco.MujocoHandle(
+        TENNICAM_CLIENT_MUJOCO_ID,
+        table=True,
+        balls=(ball,),
+        graphics=graphics,
+        accelerated_time=accelerated_time,
+    )
+    return handle
+
+
+def run(filepath: pathlib.Path):
+    """
+    Parse filepath and plays the corresponding
+    ball trajectory in mujoco (via an o80 frontend)
+    """
+
+    # configuring and staring mujoco
+    handle = _get_handle()
+
+    # getting a frontend for ball control
+    ball = handle.frontends["ball"]
+
+    # parsing file
+    ball_infos = list(tennicam_client.parse(filepath))
+
+    # duration between 2 ball observations
+    duration = o80.Duration_us.nanoseconds(ball_infos[1][1] - ball_infos[0][1])
+
+    # playing the ball trajectory
+    signal_handler.init()  # for detecting ctrl+c
+    for ball_info in ball_infos:
+        _, _, position, velocity = ball_info
+        ball.add_command(position, velocity, duration, o80.Mode.OVERWRITE)
+        ball.pulse_and_wait()
+        if signal_handler.has_received_sigint():
+            break
+
+
+if __name__ == "__main__":
+    config = _configure()
+    run(pathlib.Path(config.filepath))

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>pybind11_vendor</depend>
   <depend>shared_memory</depend>

--- a/python/tennicam_client/__init__.py
+++ b/python/tennicam_client/__init__.py
@@ -1,0 +1,2 @@
+from tennicam_client_wrp import *
+from .parser import parse

--- a/python/tennicam_client/parser.py
+++ b/python/tennicam_client/parser.py
@@ -1,0 +1,34 @@
+import typing
+import pathlib
+
+Position = typing.TypeVar("Position", float, float, float)
+Velocity = typing.TypeVar("Velocity", float, float, float)
+Entry = typing.TypeVar("Entry", int, int, Position, Velocity)
+
+
+def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:
+    """
+    Parse the file and yield information about the ball
+    
+    Args:
+        filepath: absolute path of a file generated using tennicam_client_logger
+    
+    Returns:
+        tuples: (ball_id: int, time_stamp: int, position: 3d tuple, velocity: 3d tuple)
+        time_stamp is in milliseconds.
+        ball_id is -1 if invalid ball (ball not detected by the visual tracking)
+    """
+
+    if not filepath.exists():
+        raise FileNotFoundError(
+            "tennicam_client parse: failed to find: {}".format(filepath)
+        )
+
+    with open(filepath) as f:
+        for line in f:
+            try:
+                yield eval(line)
+            except:
+                return False
+                
+    return True

--- a/python/tennicam_client/parser.py
+++ b/python/tennicam_client/parser.py
@@ -1,9 +1,9 @@
 import typing
 import pathlib
 
-Position = typing.TypeVar("Position", float, float, float)
-Velocity = typing.TypeVar("Velocity", float, float, float)
-Entry = typing.TypeVar("Entry", int, int, Position, Velocity)
+Position = typing.Sequence[float]
+Velocity = typing.Sequence[float]
+Entry = typing.Tuple[int, int, Position, Velocity]
 
 
 def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:
@@ -30,5 +30,5 @@ def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:
                 yield eval(line)
             except:
                 return False
-                
+
     return True

--- a/python/tennicam_client/parser.py
+++ b/python/tennicam_client/parser.py
@@ -15,7 +15,7 @@ def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:
     
     Returns:
         tuples: (ball_id: int, time_stamp: int, position: 3d tuple, velocity: 3d tuple)
-        time_stamp is in milliseconds.
+        time_stamp is in nanoseconds.
         ball_id is -1 if invalid ball (ball not detected by the visual tracking)
     """
 

--- a/srcpy/wrappers.cpp
+++ b/srcpy/wrappers.cpp
@@ -42,7 +42,7 @@ void add_observation(pybind11::module& m)
         });
 }
 
-PYBIND11_MODULE(tennicam_client, m)
+PYBIND11_MODULE(tennicam_client_wrp, m)
 {
     // adding update_transform_config_file, read_transform_from_memory
     // and write transform to memory


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Added a logger to tennicam_client. This logger extracts from the shared memory information about balls (via an o80 frontend) and dump the data in a file.

Added also a parse method that allows to parse the dumped file.

Added a replay executable that uses the parser to replay a file in mujoco (i.e. replay the recorded ball trajectory)

Misc: also fixed some unused imports in other executables.


## How I Tested

Ran a dummy zmq server, a tennicam_client and tennicam_client_logger. Check the logged file visually.
Replayed the logged file via tennicam_client_replay.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [X ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [X ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).

Note: pam_documentation still to be udpated.
