### PR TITLE
Reformat using black

### DIFF
--- a/bin/tennicam_client_logger.py
+++ b/bin/tennicam_client_logger.py
@@ -40,7 +40,7 @@ def _unique_path(
 def _run(segment_id: str, filepath: pathlib.Path):
     """
     Creates an o80 frontend and uses it to get all
-    ball observations and dumping a corresponding 
+    ball observations and dumping a corresponding
     string in filepath.
     """
 

--- a/bin/tennicam_client_replay.py
+++ b/bin/tennicam_client_replay.py
@@ -57,7 +57,7 @@ def _configure() -> BrightArgs:
 def _get_handle() -> pam_mujoco.MujocoHandle:
     """
     Configures mujoco to have a controllable ball
-    and returns the handle 
+    and returns the handle
     """
 
     global TENNICAM_CLIENT_MUJOCO_ID

--- a/python/tennicam_client/parser.py
+++ b/python/tennicam_client/parser.py
@@ -9,10 +9,10 @@ Entry = typing.Tuple[int, int, Position, Velocity]
 def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:
     """
     Parse the file and yield information about the ball
-    
+
     Args:
         filepath: absolute path of a file generated using tennicam_client_logger
-    
+
     Returns:
         tuples: (ball_id: int, time_stamp: int, position: 3d tuple, velocity: 3d tuple)
         time_stamp is in nanoseconds.


### PR DESCRIPTION
## Description

Run black to reformat all Python code.
This is a preparation to merging the github workflows which automatically check formatting for all pull requests.

## How I Tested

No tests done.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
