### PR TITLE
default config file now managed by the package pam_configuration

### DIFF
--- a/bin/tennicam_client.py
+++ b/bin/tennicam_client.py
@@ -15,13 +15,11 @@ import tennicam_client
 from lightargs import BrightArgs, Positive, FileExists
 
 TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
-TENNICAM_CLIENT_DEFAULT_CONFIG = "/opt/mpi-is/tennicam_client/config/config.toml"
 TENNICAM_CLIENT_DEFAULT_FREQUENCY = 200.0
 
 
 def configure():
     global TENNICAM_CLIENT_DEFAULT_SEGMENT_ID
-    global TENNICAM_CLIENT_DEFAULT_CONFIG
     global TENNICAM_CLIENT_DEFAULT_FREQUENCY
     config = BrightArgs("o80 tennicam client standalone")
     config.add_option(
@@ -32,7 +30,7 @@ def configure():
     )
     config.add_option(
         "config_path",
-        TENNICAM_CLIENT_DEFAULT_CONFIG,
+        tennicam_client.get_default_config_file(),
         "configuration file",
         str,
         [FileExists()],

--- a/bin/tennicam_client_transform_update.py
+++ b/bin/tennicam_client_transform_update.py
@@ -11,7 +11,6 @@ of tennicam_client)
 import tennicam_client
 
 TENNICAM_CLIENT_SEGMENT_ID = "tennicam_client"
-TENNICAM_CLIENT_CONFIG_PATH = "/opt/mpi-is/tennicam_client/config/config.toml"
 
 
 def _update_transform(segment_id: str, dim: int, value: float, translation: bool):
@@ -73,7 +72,7 @@ def user_update_transform(segment_id, config_file_path):
     print()
 
     save = input("\ttype 1 if you wish to save this transform: ")
-    try :
+    try:
         save = int(save)
     except:
         pass
@@ -89,4 +88,6 @@ def user_update_transform(segment_id, config_file_path):
 
 
 if __name__ == "__main__":
-    user_update_transform(TENNICAM_CLIENT_SEGMENT_ID, TENNICAM_CLIENT_CONFIG_PATH)
+    user_update_transform(
+        TENNICAM_CLIENT_SEGMENT_ID, tennicam_client.get_default_config_file()
+    )

--- a/config/where_are_the_files.txt
+++ b/config/where_are_the_files.txt
@@ -1,0 +1,2 @@
+configuration files have been moved to:
+https://github.com/intelligent-soft-robots/pam_configuration/tree/master/config/tennicam_client

--- a/include/tennicam_client/driver.hpp
+++ b/include/tennicam_client/driver.hpp
@@ -48,7 +48,7 @@ public:
      * @brief config is a path to a toml configuration file specifying
      * the tennicam host and port, as well as the transform.
      * See for example:
-     * https://github.com/intelligent-soft-robots/tennicam_client/blob/master/config/config.toml
+     * https://github.com/intelligent-soft-robots/pam_configuration/blob/master/config/tennicam_client/config.toml
      */
     Driver(std::string toml_config_file);
     /** @brief Instantiate a driver in "active transform mode", i.e. at each

--- a/include/tennicam_client/driver_config.hpp
+++ b/include/tennicam_client/driver_config.hpp
@@ -45,7 +45,7 @@ public:
  * toml_config_file being an absolute path to a toml configuration file,
  * this parses the file and returns the corresponding instance of
  * DriverConfig. Example of toml configuration file:
- * https://github.com/intelligent-soft-robots/tennicam_client/blob/master/config/config.toml
+ * https://github.com/intelligent-soft-robots/pam_configuration/blob/master/config/tennicam_client/config.toml
  */
 DriverConfig parse_toml(const std::string& toml_config_file);
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
   <depend>json_helper</depend>
   <depend>signal_handler</depend>
 
+  <exec_depend>pam_configuration</exec_depend>
+  
   <test_depend>ament_cmake_gtest</test_depend>
   
   <export>

--- a/python/tennicam_client/__init__.py
+++ b/python/tennicam_client/__init__.py
@@ -1,2 +1,2 @@
 from tennicam_client_wrp import *
-from .parser import parse
+from .parser import parse, get_default_config_file

--- a/python/tennicam_client/parser.py
+++ b/python/tennicam_client/parser.py
@@ -1,9 +1,23 @@
 import typing
 import pathlib
+import pam_configuration
 
 Position = typing.Sequence[float]
 Velocity = typing.Sequence[float]
 Entry = typing.Tuple[int, int, Position, Velocity]
+
+_CONFIG_FILE_SUFFIX = pathlib.Path("tennicam_client") / "config.toml"
+
+
+def get_default_config_file() -> pathlib.Path:
+    """
+    Returns the absolute path to the default configuration, as it has been
+    installed by the pam_configuration package, i.e.
+    ~/.mpi-is/pam//tennicam_client/config.toml (if it exists) or
+    /opt/mpi-is/pam/tennicam_client/config.toml (otherwise)
+    """
+
+    return pathlib.Path(pam_configuration.get_path()) / _CONFIG_FILE_SUFFIX
 
 
 def parse(filepath: pathlib.Path) -> typing.Generator[Entry, None, bool]:


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The configuration file is now managed by pam_configuration

## How I Tested

- Ran the unit tests
- Ran the executables

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
