### PR TITLE
fix: Rotations were applied in negative direction

### DIFF
--- a/include/tennicam_client/transform.hpp
+++ b/include/tennicam_client/transform.hpp
@@ -14,7 +14,8 @@ class Transform
 {
 public:
     /**
-     * rotation: array of 3 angles in radians (Euler angles)
+     * @param translation (x, y, z)-translation applied after rotation.
+     * @param rotation Extrinsic xyz Euler angles in radian.
      */
     Transform(std::array<double, 3> translation,
               std::array<double, 3> rotation);

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -13,21 +13,21 @@ Transform::Transform(std::array<double, 3> translation,
     arma::Mat<double> Rx(3, 3, arma::fill::zeros);
     Rx(0, 0) = 1;
     Rx(1, 1) = +cos(rotation[0]);
-    Rx(1, 2) = +sin(rotation[0]);
-    Rx(2, 1) = -sin(rotation[0]);
+    Rx(1, 2) = -sin(rotation[0]);
+    Rx(2, 1) = +sin(rotation[0]);
     Rx(2, 2) = +cos(rotation[0]);
 
     arma::Mat<double> Ry(3, 3, arma::fill::zeros);
     Ry(0, 0) = +cos(rotation[1]);
-    Ry(0, 2) = -sin(rotation[1]);
+    Ry(0, 2) = +sin(rotation[1]);
     Ry(1, 1) = 1;
-    Ry(2, 0) = +sin(rotation[1]);
+    Ry(2, 0) = -sin(rotation[1]);
     Ry(2, 2) = +cos(rotation[1]);
 
     arma::Mat<double> Rz(3, 3, arma::fill::zeros);
     Rz(0, 0) = +cos(rotation[2]);
-    Rz(0, 1) = +sin(rotation[2]);
-    Rz(1, 0) = -sin(rotation[2]);
+    Rz(0, 1) = -sin(rotation[2]);
+    Rz(1, 0) = +sin(rotation[2]);
     Rz(1, 1) = +cos(rotation[2]);
     Rz(2, 2) = 1;
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -84,32 +84,32 @@ TEST_F(TennicamClientTests, axis_rotation)
 
     std::array<double, 3> rotation_x;
     rotation_x.fill(0);
-    rotation_x[0] = M_PI;
+    rotation_x[0] = M_PI / 2;
     Transform t_x{translation, rotation_x};
     std::array<double, 3> in_x{0, 1, 1};
     std::array<double, 3> out_x = t_x.apply(in_x);
     ASSERT_DOUBLE_EQ(out_x[0], 0.);
     ASSERT_DOUBLE_EQ(out_x[1], -1.);
-    ASSERT_DOUBLE_EQ(out_x[2], -1.);
+    ASSERT_DOUBLE_EQ(out_x[2], 1.);
 
     std::array<double, 3> rotation_y;
     rotation_y.fill(0);
-    rotation_y[1] = M_PI;
+    rotation_y[1] = M_PI / 2;
     Transform t_y{translation, rotation_y};
     std::array<double, 3> in_y{1, 0, 1};
     std::array<double, 3> out_y = t_y.apply(in_y);
-    ASSERT_DOUBLE_EQ(out_y[0], -1);
+    ASSERT_DOUBLE_EQ(out_y[0], 1);
     ASSERT_DOUBLE_EQ(out_y[1], 0);
     ASSERT_DOUBLE_EQ(out_y[2], -1);
 
     std::array<double, 3> rotation_z;
     rotation_z.fill(0);
-    rotation_z[2] = M_PI;
+    rotation_z[2] = M_PI / 2;
     Transform t_z{translation, rotation_z};
     std::array<double, 3> in_z{1, 1, 0};
     std::array<double, 3> out_z = t_z.apply(in_z);
     ASSERT_DOUBLE_EQ(out_z[0], -1);
-    ASSERT_DOUBLE_EQ(out_z[1], -1);
+    ASSERT_DOUBLE_EQ(out_z[1], 1);
     ASSERT_DOUBLE_EQ(out_z[2], 0);
 }
 


### PR DESCRIPTION
## Description

While trying to figure out which exact Euler convention is used for the rotation in the config file, I realised that when constructing the rotation matrix in `Transform`, the rotations around the individual axes where applied in negative direction (which I assume was not intentional?).
The unit test did not catch this, because it used a rotation of 180° (where both directions result in the same point).

I changed the test to use only 90° (which made it fail) and fixed the direction of the rotations (which makes the test pass again).  With this change, it now corresponds to extrinsic xyz Euler angles, which I assume was the intention.

Note that **this will break rotations in existing configurations**.  However, at least the default config does not apply a rotation (all values zero), in which case, it doesn't matter.


## How I Tested

Through the unit tests and with a simple Python script that finds the correct Euler convention via brute force.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
