### PR TITLE
chore: Disable formatting and include sorting for toml.hpp

### DIFF
--- a/include/tennicam_client/toml/_clang-format
+++ b/include/tennicam_client/toml/_clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
This is a third-party file and thus should be left untouched. Unfortunately, it seems the `clang-format off` comment in the file does not disable the include sorting.  Therefore add a clang-format config file that disables both formatting and include sorting for the whole directory.

