### PR TITLE
tennicam_client_display: Set table pose by Vicon

### DIFF
--- a/bin/tennicam_client_display.py
+++ b/bin/tennicam_client_display.py
@@ -31,10 +31,10 @@ TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
 
 def _get_vicon_table_pose(vicon_segment_id: str) -> Transformation:
     # only import if actually needed
-    import pam_vicon_o80
+    import pam_vicon
 
     logging.info("Get table pose from Vicon (using segment id '%s')", vicon_segment_id)
-    vicon = pam_vicon_o80.PamVicon(vicon_segment_id)
+    vicon = pam_vicon.PamVicon(vicon_segment_id)
     vicon.update()
     return vicon.get_table_pose(yaw_only=True)
 

--- a/bin/tennicam_client_display.py
+++ b/bin/tennicam_client_display.py
@@ -1,17 +1,25 @@
 #!/usr/bin/env python3
 
-"""
-Display in a mujoco simulated environment the ball
-as published by tennicam.
+"""Display in a MuJoCo simulated environment the ball as published by tennicam.
+
 Required for this executable:
 - in a first terminal: 'tennicam_client'
-- in second terminal :'pam_mujoco tennicam_client_display'
+- in second terminal: 'pam_mujoco tennicam_client_display'
+- [if Vicon is used] in a third terminal: 'vicon_o80_standalone <IP>'
 """
+from __future__ import annotations
+
+import argparse
+import logging
+import typing as t
 
 import o80
 import signal_handler
 import tennicam_client
 import pam_mujoco
+
+if t.TYPE_CHECKING:
+    from vicon_transformer.transform import Transformation
 
 
 # required for this executable:
@@ -21,28 +29,65 @@ import pam_mujoco
 TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
 
 
-def _get_handle():
+def _get_vicon_table_pose(vicon_segment_id: str) -> Transformation:
+    # only import if actually needed
+    import pam_vicon_o80
+
+    logging.info("Get table pose from Vicon (using segment id '%s')", vicon_segment_id)
+    vicon = pam_vicon_o80.PamVicon(vicon_segment_id)
+    vicon.update()
+    return vicon.get_table_pose(yaw_only=True)
+
+
+def _get_handle(vicon_segment_id: t.Optional[str] = None) -> pam_mujoco.MujocoHandle:
     ball = pam_mujoco.MujocoItem(
         "ball", control=pam_mujoco.MujocoItem.CONSTANT_CONTROL, color=(1, 0, 0, 1)
     )
     table = pam_mujoco.MujocoTable("table")
+
+    if vicon_segment_id:
+        table_pose = _get_vicon_table_pose(vicon_segment_id)
+        table.position = table_pose.translation.tolist()
+        table.orientation = table_pose.rotation
+
     graphics = True
     accelerated_time = False
     handle = pam_mujoco.MujocoHandle(
         "tennicam_client_display",
         table=table,
-        balls=(ball,),
+        balls=[ball],
         graphics=graphics,
         accelerated_time=accelerated_time,
     )
     return handle
 
 
-def run():
+def run() -> None:
     global TENNICAM_CLIENT_DEFAULT_SEGMENT_ID
 
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--vicon",
+        type=str,
+        dest="vicon_segment_id",
+        metavar="<segment id>",
+        nargs="?",
+        const="vicon",  # default if '--vicon' is set without a value
+        help="""Get table pose from Vicon.  This requires an PAM o80 Vicon backend
+            running with the specified segment ID (default: "%(const)s").
+        """,
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="[hysr_visualization.%(name)s] [%(levelname)s] %(message)s",
+        level=logging.INFO,
+    )
+
     # configuring and staring mujoco
-    handle = _get_handle()
+    handle = _get_handle(args.vicon_segment_id)
 
     # getting a frontend for ball control
     ball = handle.frontends["ball"]


### PR DESCRIPTION
## Description

Add a `--vicon` option to `tennicam_client_display` to set the table pose based on Vicon.  In this case a corresponding o80 back end for Vicon needs to be running in a separate process.


## How I Tested

By running it and moving a ball along the edges of the table to see if real world and visualisation match.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
